### PR TITLE
Fix switch for static bindings

### DIFF
--- a/args.c
+++ b/args.c
@@ -138,11 +138,10 @@ void parse_args(int argc, char *argv[], address_pool *pool)
 		free(ip);
 		free(hw);
 		free(opt);
+		break;
 	    }
 	    
 	case '?':
-	    usage(NULL, 1);
-
 	default:
 	    usage(NULL, 1);
 	}


### PR DESCRIPTION
When static bindings are supplied, the server wrongly outputs the help and exits due to the missing break and therefore following execution of the help/default case.
The lines 144/145 is just the removal of redundant code.